### PR TITLE
Add empty list test

### DIFF
--- a/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
+++ b/org.jacoco.core.test/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilterTest.java
@@ -48,6 +48,17 @@ public class KotlinDefaultArgumentsFilterTest extends FilterTestBase {
 		return m;
 	}
 
+	@Test(expected = NullPointerException.class)
+	public void empty_instructions_list() {
+		final MethodNode m = new MethodNode(InstrSupport.ASM_API_VERSION,
+				Opcodes.ACC_SYNTHETIC, "origin$default", "(LTarget;IILjava/lang/Object;)V", null, null);
+
+		context.classAnnotations
+				.add(KotlinGeneratedFilter.KOTLIN_METADATA_DESC);
+
+		filter.filter(m, context, output);
+	}
+
 	@Test
 	public void should_filter() {
 		final MethodNode m = createMethod(Opcodes.ACC_SYNTHETIC,


### PR DESCRIPTION
[KotlinDefaultArgumentsFilter](https://github.com/quentin-jaquier-sonarsource/jacoco/blob/master/org.jacoco.core/src/org/jacoco/core/internal/analysis/filter/KotlinDefaultArgumentsFilter.java#L74)

A null pointer can arise at line (74) if the head of the instructions list is null (line 68, cursor = methodNode.instructions.getFirst()).